### PR TITLE
Fix invalid scoping

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -1,12 +1,10 @@
 if (!Object.hasOwn) {
-  var hasOwnProperty = Object.prototype.hasOwnProperty
-
   Object.defineProperty(Object, "hasOwn", {
     value: function (object, property) {
       if (object == null) {
         throw new TypeError("Cannot convert undefined or null to object")
       }
-      return hasOwnProperty.call(Object(object), property)
+      return Object.prototype.hasOwnProperty.call(Object(object), property)
     },
     configurable: true,
     enumerable: false,


### PR DESCRIPTION
`var` is function scoped, so `hasOwnProperty` was leaked as a global variable.

This just removes the variable