### PR TITLE
Add reference to Babel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Polyfills of `Object.hasOwn()` are available in:
 - [npm: object.hasown](https://www.npmjs.com/package/object.hasown)
 - [core-js](https://github.com/zloirock/core-js/#accessible-objecthasownproperty)
 
+Babel plugin is available:
+
+- [babel-plugin-transform-object-hasown](https://github.com/niksy/babel-plugin-transform-object-hasown)
+
 ## Q&A
 
 ### Why not `Object.hasOwnProperty(object, property)`?


### PR DESCRIPTION
I’ve created Babel plugin which should transform code similar to the rules for official `Object.assign` transform. Transformed code follows [polyfill](https://github.com/tc39/proposal-accessible-object-hasownproperty/blob/main/polyfill.js) in this repo.